### PR TITLE
Lt8315

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -10616,6 +10616,33 @@ Pulse Transformers 1CT:1 200 UH
 <text x="0" y="-12.7" size="1.27" layer="95" align="top-left">&gt;MPN</text>
 <text x="0" y="1.016" size="1.27" layer="95">&gt;NAME</text>
 </symbol>
+<symbol name="LT8315">
+<description>LT8315 560VIN Micropower No-Opto
+Isolated Flyback Converter with 630V/300mA Switch
+
+&lt;br&gt;
+&lt;a href="https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<pin name="EN/UVLO" x="-2.54" y="-10.16" length="short" direction="in"/>
+<pin name="INTVCC" x="-2.54" y="-15.24" length="short" direction="pas"/>
+<pin name="SMODE" x="-2.54" y="-20.32" length="short" direction="in"/>
+<pin name="VC" x="-2.54" y="-25.4" length="short" direction="pas"/>
+<pin name="IREG/SS" x="7.62" y="-38.1" length="short" direction="pas" rot="R90"/>
+<pin name="SOURCE" x="27.94" y="-25.4" length="short" direction="out" rot="R180"/>
+<pin name="DRAIN" x="27.94" y="-20.32" length="short" direction="oc" rot="R180"/>
+<pin name="TC" x="27.94" y="-15.24" length="short" direction="pas" rot="R180"/>
+<pin name="FB" x="27.94" y="-10.16" length="short" direction="in" rot="R180"/>
+<pin name="DCM" x="12.7" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="GND" x="12.7" y="-38.1" length="short" direction="pwr" rot="R90"/>
+<wire x1="0" y1="0" x2="25.4" y2="0" width="0.1524" layer="94"/>
+<wire x1="25.4" y1="0" x2="25.4" y2="-35.56" width="0.1524" layer="94"/>
+<wire x1="25.4" y1="-35.56" x2="0" y2="-35.56" width="0.1524" layer="94"/>
+<wire x1="0" y1="-35.56" x2="0" y2="0" width="0.1524" layer="94"/>
+<text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
+<text x="0" y="-36.322" size="1.27" layer="96" align="top-left">&gt;MPN</text>
+<pin name="BIAS" x="7.62" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="EP" x="17.78" y="-38.1" length="short" direction="pwr" rot="R90"/>
+<pin name="NC" x="17.78" y="2.54" length="short" direction="nc" rot="R270"/>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="CONNECTOR-2_?_*" prefix="J">
@@ -18107,6 +18134,44 @@ RS422 Transreceiver
 <attribute name="MANUFACTURER" value="Analog Devices Inc."/>
 <attribute name="MOPN" value="584-ADM4854ARZ"/>
 <attribute name="MPN" value="ADM4854ARZ"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="LT8315">
+<description>LT8315 560VIN Micropower No-Opto
+Isolated Flyback Converter with 630V/300mA Switch
+
+&lt;br&gt;
+&lt;a href="https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="LT8315" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="TSSOP-20(16)">
+<connects>
+<connect gate="G$1" pin="BIAS" pad="9"/>
+<connect gate="G$1" pin="DCM" pad="10"/>
+<connect gate="G$1" pin="DRAIN" pad="1 2 3"/>
+<connect gate="G$1" pin="EN/UVLO" pad="17"/>
+<connect gate="G$1" pin="EP" pad="THERMAL"/>
+<connect gate="G$1" pin="FB" pad="12"/>
+<connect gate="G$1" pin="GND" pad="15 20"/>
+<connect gate="G$1" pin="INTVCC" pad="8"/>
+<connect gate="G$1" pin="IREG/SS" pad="14"/>
+<connect gate="G$1" pin="NC" pad="19"/>
+<connect gate="G$1" pin="SMODE" pad="16"/>
+<connect gate="G$1" pin="SOURCE" pad="18"/>
+<connect gate="G$1" pin="TC" pad="11"/>
+<connect gate="G$1" pin="VC" pad="13"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DKPN" value="505-LT8315HFE#PBF-ND"/>
+<attribute name="MANUFACTURER" value="Analog Devices Inc."/>
+<attribute name="MOPN" value="584-LT8315HFEPBF"/>
+<attribute name="MPN" value="LT8315HFE#PBF"/>
 </technology>
 </technologies>
 </device>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="16" fill="1" visible="no" active="yes"/>
@@ -265,8 +265,9 @@ Isolated Flyback Converter with 630V/300mA Switch
 <connect gate="G$1" pin="DCM" pad="10"/>
 <connect gate="G$1" pin="DRAIN" pad="1 2 3"/>
 <connect gate="G$1" pin="EN/UVLO" pad="17"/>
+<connect gate="G$1" pin="EP" pad="THERMAL"/>
 <connect gate="G$1" pin="FB" pad="12"/>
-<connect gate="G$1" pin="GND" pad="15"/>
+<connect gate="G$1" pin="GND" pad="15 20"/>
 <connect gate="G$1" pin="INTVCC" pad="8"/>
 <connect gate="G$1" pin="IREG/SS" pad="14"/>
 <connect gate="G$1" pin="NC" pad="19"/>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -191,6 +191,33 @@
 </layers>
 <library>
 <packages>
+<package name="TSSOP-20(16)">
+<description>TSSOP-20 with 4 pins removed</description>
+<smd name="1" x="-2.925" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="2" x="-2.275" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="3" x="-1.625" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="8" x="1.625" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="9" x="2.275" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="10" x="2.925" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="11" x="2.925" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="12" x="2.275" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="13" x="1.625" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="14" x="0.975" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="15" x="0.325" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="16" x="-0.325" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="17" x="-0.975" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="18" x="-1.625" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="19" x="-2.275" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<smd name="20" x="-2.925" y="2.775" dx="0.45" dy="1.05" layer="1"/>
+<wire x1="-3.3" y1="2.25" x2="3.3" y2="2.25" width="0.127" layer="21"/>
+<wire x1="3.3" y1="2.25" x2="3.3" y2="-2.25" width="0.127" layer="21"/>
+<wire x1="3.3" y1="-2.25" x2="-3.3" y2="-2.25" width="0.127" layer="21"/>
+<wire x1="-3.3" y1="-2.25" x2="-3.3" y2="2.25" width="0.127" layer="21"/>
+<text x="-3.81" y="0" size="0.8128" layer="25" font="vector" rot="R90" align="bottom-center">&gt;NAME</text>
+<circle x="-3.81" y="-2.794" radius="0.254" width="0" layer="21"/>
+<rectangle x1="-3.556" y1="-3.556" x2="3.556" y2="3.556" layer="39"/>
+<smd name="THERMAL" x="0" y="0.47" dx="5.68" dy="1.78" layer="1"/>
+</package>
 </packages>
 <symbols>
 <symbol name="LT8315">
@@ -199,27 +226,40 @@ Isolated Flyback Converter with 630V/300mA Switch
 
 &lt;br&gt;
 &lt;a href="https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<pin name="EN/UVLO" x="-2.54" y="-10.16" length="short"/>
-<pin name="INTVCC" x="-2.54" y="-15.24" length="short"/>
-<pin name="SMODE" x="-2.54" y="-20.32" length="short"/>
-<pin name="VC" x="-2.54" y="-25.4" length="short"/>
-<pin name="IREG" x="10.16" y="-38.1" length="short" rot="R90"/>
-<pin name="SOURCE" x="27.94" y="-25.4" length="short" rot="R180"/>
-<pin name="DRAIN" x="27.94" y="-20.32" length="short" rot="R180"/>
-<pin name="TC" x="27.94" y="-15.24" length="short" rot="R180"/>
-<pin name="FB" x="27.94" y="-10.16" length="short" rot="R180"/>
-<pin name="DCM" x="15.24" y="2.54" length="short" rot="R270"/>
-<pin name="GND" x="15.24" y="-38.1" length="short" rot="R90"/>
+<pin name="EN/UVLO" x="-2.54" y="-10.16" length="short" direction="in"/>
+<pin name="INTVCC" x="-2.54" y="-15.24" length="short" direction="pas"/>
+<pin name="SMODE" x="-2.54" y="-20.32" length="short" direction="in"/>
+<pin name="VC" x="-2.54" y="-25.4" length="short" direction="pas"/>
+<pin name="IREG" x="10.16" y="-38.1" length="short" direction="pas" rot="R90"/>
+<pin name="SOURCE" x="27.94" y="-25.4" length="short" direction="out" rot="R180"/>
+<pin name="DRAIN" x="27.94" y="-20.32" length="short" direction="oc" rot="R180"/>
+<pin name="TC" x="27.94" y="-15.24" length="short" direction="pas" rot="R180"/>
+<pin name="FB" x="27.94" y="-10.16" length="short" direction="in" rot="R180"/>
+<pin name="DCM" x="15.24" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="GND" x="15.24" y="-38.1" length="short" direction="pwr" rot="R90"/>
 <wire x1="0" y1="0" x2="25.4" y2="0" width="0.1524" layer="94"/>
 <wire x1="25.4" y1="0" x2="25.4" y2="-35.56" width="0.1524" layer="94"/>
 <wire x1="25.4" y1="-35.56" x2="0" y2="-35.56" width="0.1524" layer="94"/>
 <wire x1="0" y1="-35.56" x2="0" y2="0" width="0.1524" layer="94"/>
 <text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
 <text x="0" y="-36.322" size="1.27" layer="96" align="top-left">&gt;MPN</text>
-<pin name="BIAS" x="10.16" y="2.54" length="short" rot="R270"/>
+<pin name="BIAS" x="10.16" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="EP" x="20.32" y="-38.1" length="short" direction="pwr" rot="R90"/>
+<pin name="NC" x="20.32" y="2.54" length="short" direction="nc" rot="R270"/>
 </symbol>
 </symbols>
 <devicesets>
+<deviceset name="LT8315">
+<gates>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 </drawing>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -230,32 +230,58 @@ Isolated Flyback Converter with 630V/300mA Switch
 <pin name="INTVCC" x="-2.54" y="-15.24" length="short" direction="pas"/>
 <pin name="SMODE" x="-2.54" y="-20.32" length="short" direction="in"/>
 <pin name="VC" x="-2.54" y="-25.4" length="short" direction="pas"/>
-<pin name="IREG" x="10.16" y="-38.1" length="short" direction="pas" rot="R90"/>
+<pin name="IREG/SS" x="7.62" y="-38.1" length="short" direction="pas" rot="R90"/>
 <pin name="SOURCE" x="27.94" y="-25.4" length="short" direction="out" rot="R180"/>
 <pin name="DRAIN" x="27.94" y="-20.32" length="short" direction="oc" rot="R180"/>
 <pin name="TC" x="27.94" y="-15.24" length="short" direction="pas" rot="R180"/>
 <pin name="FB" x="27.94" y="-10.16" length="short" direction="in" rot="R180"/>
-<pin name="DCM" x="15.24" y="2.54" length="short" direction="in" rot="R270"/>
-<pin name="GND" x="15.24" y="-38.1" length="short" direction="pwr" rot="R90"/>
+<pin name="DCM" x="12.7" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="GND" x="12.7" y="-38.1" length="short" direction="pwr" rot="R90"/>
 <wire x1="0" y1="0" x2="25.4" y2="0" width="0.1524" layer="94"/>
 <wire x1="25.4" y1="0" x2="25.4" y2="-35.56" width="0.1524" layer="94"/>
 <wire x1="25.4" y1="-35.56" x2="0" y2="-35.56" width="0.1524" layer="94"/>
 <wire x1="0" y1="-35.56" x2="0" y2="0" width="0.1524" layer="94"/>
 <text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
 <text x="0" y="-36.322" size="1.27" layer="96" align="top-left">&gt;MPN</text>
-<pin name="BIAS" x="10.16" y="2.54" length="short" direction="in" rot="R270"/>
-<pin name="EP" x="20.32" y="-38.1" length="short" direction="pwr" rot="R90"/>
-<pin name="NC" x="20.32" y="2.54" length="short" direction="nc" rot="R270"/>
+<pin name="BIAS" x="7.62" y="2.54" length="short" direction="in" rot="R270"/>
+<pin name="EP" x="17.78" y="-38.1" length="short" direction="pwr" rot="R90"/>
+<pin name="NC" x="17.78" y="2.54" length="short" direction="nc" rot="R270"/>
 </symbol>
 </symbols>
 <devicesets>
 <deviceset name="LT8315">
+<description>LT8315 560VIN Micropower No-Opto
+Isolated Flyback Converter with 630V/300mA Switch
+
+&lt;br&gt;
+&lt;a href="https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf"&gt;Datasheet&lt;/a&gt;</description>
 <gates>
+<gate name="G$1" symbol="LT8315" x="0" y="0"/>
 </gates>
 <devices>
-<device name="">
+<device name="" package="TSSOP-20(16)">
+<connects>
+<connect gate="G$1" pin="BIAS" pad="9"/>
+<connect gate="G$1" pin="DCM" pad="10"/>
+<connect gate="G$1" pin="DRAIN" pad="1 2 3"/>
+<connect gate="G$1" pin="EN/UVLO" pad="17"/>
+<connect gate="G$1" pin="FB" pad="12"/>
+<connect gate="G$1" pin="GND" pad="15"/>
+<connect gate="G$1" pin="INTVCC" pad="8"/>
+<connect gate="G$1" pin="IREG/SS" pad="14"/>
+<connect gate="G$1" pin="NC" pad="19"/>
+<connect gate="G$1" pin="SMODE" pad="16"/>
+<connect gate="G$1" pin="SOURCE" pad="18"/>
+<connect gate="G$1" pin="TC" pad="11"/>
+<connect gate="G$1" pin="VC" pad="13"/>
+</connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DKPN" value="505-LT8315HFE#PBF-ND"/>
+<attribute name="MANUFACTURER" value="Analog Devices Inc."/>
+<attribute name="MOPN" value="584-LT8315HFEPBF"/>
+<attribute name="MPN" value="LT8315HFE#PBF"/>
+</technology>
 </technologies>
 </device>
 </devices>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.6.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="Route2" color="16" fill="1" visible="no" active="yes"/>
+<layer number="3" name="Route3" color="17" fill="1" visible="no" active="yes"/>
+<layer number="4" name="Route4" color="18" fill="1" visible="no" active="yes"/>
+<layer number="5" name="Route5" color="19" fill="1" visible="no" active="yes"/>
+<layer number="6" name="Route6" color="25" fill="1" visible="no" active="yes"/>
+<layer number="7" name="Route7" color="26" fill="1" visible="no" active="yes"/>
+<layer number="8" name="Route8" color="27" fill="1" visible="no" active="yes"/>
+<layer number="9" name="Route9" color="28" fill="1" visible="no" active="yes"/>
+<layer number="10" name="Route10" color="29" fill="1" visible="no" active="yes"/>
+<layer number="11" name="Route11" color="30" fill="1" visible="no" active="yes"/>
+<layer number="12" name="Route12" color="20" fill="1" visible="no" active="yes"/>
+<layer number="13" name="Route13" color="21" fill="1" visible="no" active="yes"/>
+<layer number="14" name="Route14" color="22" fill="1" visible="no" active="yes"/>
+<layer number="15" name="Route15" color="23" fill="1" visible="no" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="58" name="bCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="99" name="SpiceOrder" color="7" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="no" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="no" active="yes"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="no" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="117" name="mPads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="119" name="mUnrouted" color="7" fill="1" visible="no" active="yes"/>
+<layer number="120" name="mDimension" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
+<layer number="130" name="mbStop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="133" name="mtFinish" color="7" fill="1" visible="no" active="yes"/>
+<layer number="134" name="mbFinish" color="7" fill="1" visible="no" active="yes"/>
+<layer number="135" name="mtGlue" color="7" fill="1" visible="no" active="yes"/>
+<layer number="136" name="mbGlue" color="7" fill="1" visible="no" active="yes"/>
+<layer number="137" name="mtTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="138" name="mbTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="139" name="mtKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="140" name="mbKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="141" name="mtRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="142" name="mbRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="143" name="mvRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="145" name="mHoles" color="7" fill="1" visible="no" active="yes"/>
+<layer number="146" name="mMilling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="147" name="mMeasures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="148" name="mDocument" color="7" fill="1" visible="no" active="yes"/>
+<layer number="149" name="mReference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="156" name="HVSpacing" color="12" fill="1" visible="no" active="yes"/>
+<layer number="157" name="HIGH_VOLTAGE_WIRES" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="166" name="AntennaArea" color="7" fill="1" visible="no" active="no"/>
+<layer number="168" name="4mmHeightArea" color="7" fill="1" visible="no" active="no"/>
+<layer number="191" name="mNets" color="7" fill="1" visible="no" active="yes"/>
+<layer number="192" name="mBusses" color="7" fill="1" visible="no" active="yes"/>
+<layer number="193" name="mPins" color="7" fill="1" visible="no" active="yes"/>
+<layer number="194" name="mSymbols" color="7" fill="1" visible="no" active="yes"/>
+<layer number="195" name="mNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="196" name="mValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="252" name="BR-BS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="253" name="BR-LS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
+</layers>
+<library>
+<packages>
+</packages>
+<symbols>
+<symbol name="LT8315">
+<description>LT8315 560VIN Micropower No-Opto
+Isolated Flyback Converter with 630V/300mA Switch
+
+&lt;br&gt;
+&lt;a href="https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<pin name="EN/UVLO" x="-2.54" y="-10.16" length="short"/>
+<pin name="INTVCC" x="-2.54" y="-15.24" length="short"/>
+<pin name="SMODE" x="-2.54" y="-20.32" length="short"/>
+<pin name="VC" x="-2.54" y="-25.4" length="short"/>
+<pin name="IREG" x="10.16" y="-38.1" length="short" rot="R90"/>
+<pin name="SOURCE" x="27.94" y="-25.4" length="short" rot="R180"/>
+<pin name="DRAIN" x="27.94" y="-20.32" length="short" rot="R180"/>
+<pin name="TC" x="27.94" y="-15.24" length="short" rot="R180"/>
+<pin name="FB" x="27.94" y="-10.16" length="short" rot="R180"/>
+<pin name="DCM" x="15.24" y="2.54" length="short" rot="R270"/>
+<pin name="GND" x="15.24" y="-38.1" length="short" rot="R90"/>
+<wire x1="0" y1="0" x2="25.4" y2="0" width="0.1524" layer="94"/>
+<wire x1="25.4" y1="0" x2="25.4" y2="-35.56" width="0.1524" layer="94"/>
+<wire x1="25.4" y1="-35.56" x2="0" y2="-35.56" width="0.1524" layer="94"/>
+<wire x1="0" y1="-35.56" x2="0" y2="0" width="0.1524" layer="94"/>
+<text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
+<text x="0" y="-36.322" size="1.27" layer="96" align="top-left">&gt;MPN</text>
+<pin name="BIAS" x="10.16" y="2.54" length="short" rot="R270"/>
+</symbol>
+</symbols>
+<devicesets>
+</devicesets>
+</library>
+</drawing>
+</eagle>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
LT8315 560V No Opto-Isolator Flyback Converter with 630V/300mA device (same footprint, new symbol and device)

## Additional Information
(https://www.analog.com/media/en/technical-documentation/data-sheets/8315fa.pdf)

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?
