### PR TITLE
STM32-LQFP64

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -6237,6 +6237,80 @@ Pulse Transformers 1CT:1 200 UH
 <circle x="0" y="0" radius="5.25" width="10.5" layer="39"/>
 <text x="0" y="10.652" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
 </package>
+<package name="STM32-FOOTPRINT">
+<description>https://www.st.com/content/ccc/resource/technical/document/datasheet/65/cb/75/50/53/d6/48/24/DM00141306.pdf/files/DM00141306.pdf/jcr:content/translations/en.DM00141306.pdf</description>
+<smd name="P$15" x="3.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$16" x="3.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$9" x="0.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$10" x="0.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$11" x="1.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$12" x="1.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$14" x="2.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$13" x="2.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$8" x="-0.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$7" x="-0.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$6" x="-1.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$5" x="-1.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$4" x="-2.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$3" x="-2.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$2" x="-3.25" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$1" x="-3.75" y="-5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$17" x="5.75" y="-3.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$18" x="5.75" y="-3.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$19" x="5.75" y="-2.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$20" x="5.75" y="-2.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$21" x="5.75" y="-1.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$22" x="5.75" y="-1.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$23" x="5.75" y="-0.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$24" x="5.75" y="-0.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$25" x="5.75" y="0.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$26" x="5.75" y="0.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$27" x="5.75" y="1.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$28" x="5.75" y="1.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$29" x="5.75" y="2.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$30" x="5.75" y="2.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$31" x="5.75" y="3.25" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$32" x="5.75" y="3.75" dx="1.2" dy="0.3" layer="1"/>
+<smd name="P$33" x="3.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$34" x="3.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$35" x="2.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$36" x="2.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$37" x="1.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$38" x="1.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$39" x="0.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$40" x="0.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$41" x="-0.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$42" x="-0.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$43" x="-1.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$44" x="-1.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$45" x="-2.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$46" x="-2.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$47" x="-3.25" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$48" x="-3.75" y="5.75" dx="1.2" dy="0.3" layer="1" rot="R90"/>
+<smd name="P$49" x="-5.75" y="3.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$50" x="-5.75" y="3.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$51" x="-5.75" y="2.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$52" x="-5.75" y="2.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$53" x="-5.75" y="1.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$54" x="-5.75" y="1.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$55" x="-5.75" y="0.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$56" x="-5.75" y="0.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$57" x="-5.75" y="-0.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$58" x="-5.75" y="-0.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$59" x="-5.75" y="-1.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$60" x="-5.75" y="-1.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$61" x="-5.75" y="-2.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$62" x="-5.75" y="-2.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$63" x="-5.75" y="-3.25" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<smd name="P$64" x="-5.75" y="-3.75" dx="1.2" dy="0.3" layer="1" rot="R180"/>
+<wire x1="-5" y1="5" x2="-5" y2="-5" width="0.254" layer="21"/>
+<wire x1="-5" y1="-5" x2="5" y2="-5" width="0.254" layer="21"/>
+<wire x1="5" y1="-5" x2="5" y2="5" width="0.254" layer="21"/>
+<wire x1="5" y1="5" x2="-5" y2="5" width="0.254" layer="21"/>
+<rectangle x1="-7" y1="-7" x2="7" y2="7" layer="39"/>
+<text x="0" y="7" size="0.8128" layer="25" align="bottom-center">&gt;NAME</text>
+<circle x="-3.81" y="-7.62" radius="0.127" width="0.254" layer="21"/>
+</package>
 </packages>
 <symbols>
 <symbol name="VOLTAGE_REGULATOR">
@@ -10984,6 +11058,78 @@ Isolated Flyback Converter with 630V/300mA Switch
 <wire x1="0" y1="0" x2="22.86" y2="0" width="0.254" layer="94"/>
 <text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
 <text x="0" y="-43.942" size="1.27" layer="96" rot="MR180">&gt;MPN</text>
+</symbol>
+<symbol name="STM32-SYMBOL">
+<pin name="VBAT" x="-30.48" y="17.78" length="short" direction="sup"/>
+<pin name="PC13" x="-30.48" y="15.24" length="short"/>
+<pin name="PC14-OSC32_IN" x="-30.48" y="12.7" length="short"/>
+<pin name="PC15-OSC32_OUT" x="-30.48" y="10.16" length="short"/>
+<pin name="PH0-OSC_IN" x="-30.48" y="7.62" length="short"/>
+<pin name="PH1-OSC_OUT" x="-30.48" y="5.08" length="short"/>
+<pin name="NRST" x="-30.48" y="2.54" length="short"/>
+<pin name="PC0" x="-30.48" y="0" length="short"/>
+<pin name="PC1" x="-30.48" y="-2.54" length="short"/>
+<pin name="PC2" x="-30.48" y="-5.08" length="short"/>
+<pin name="PC3" x="-30.48" y="-7.62" length="short"/>
+<pin name="VSSA/VREF-" x="-30.48" y="-10.16" length="short" direction="sup" function="dot"/>
+<pin name="VDDA/VREF+" x="-30.48" y="-12.7" length="short" direction="sup"/>
+<pin name="PA0" x="-30.48" y="-15.24" length="short"/>
+<pin name="PA1" x="-30.48" y="-17.78" length="short"/>
+<pin name="PA2" x="-30.48" y="-20.32" length="short"/>
+<pin name="PA3" x="-17.78" y="-33.02" length="short" rot="R90"/>
+<pin name="VSS" x="-15.24" y="-33.02" length="short" direction="sup" rot="R90"/>
+<pin name="VDD" x="-12.7" y="-33.02" length="short" direction="sup" rot="R90"/>
+<pin name="PA4" x="-10.16" y="-33.02" length="short" rot="R90"/>
+<pin name="PA5" x="-7.62" y="-33.02" length="short" rot="R90"/>
+<pin name="PA6" x="-5.08" y="-33.02" length="short" rot="R90"/>
+<pin name="PA7" x="-2.54" y="-33.02" length="short" rot="R90"/>
+<pin name="PC4" x="0" y="-33.02" length="short" rot="R90"/>
+<pin name="PC5" x="2.54" y="-33.02" length="short" rot="R90"/>
+<pin name="PB0" x="5.08" y="-33.02" length="short" rot="R90"/>
+<pin name="PB1" x="7.62" y="-33.02" length="short" rot="R90"/>
+<pin name="PB2" x="10.16" y="-33.02" length="short" rot="R90"/>
+<pin name="PB10" x="12.7" y="-33.02" length="short" rot="R90"/>
+<pin name="VCAP_1" x="15.24" y="-33.02" length="short" direction="sup" rot="R90"/>
+<pin name="VSS1" x="17.78" y="-33.02" length="short" direction="sup" rot="R90"/>
+<pin name="VDD1" x="20.32" y="-33.02" length="short" direction="sup" rot="R90"/>
+<pin name="PB12" x="33.02" y="-20.32" length="short" rot="R180"/>
+<pin name="PB13" x="33.02" y="-17.78" length="short" rot="R180"/>
+<pin name="PB14" x="33.02" y="-15.24" length="short" rot="R180"/>
+<pin name="PB15" x="33.02" y="-12.7" length="short" rot="R180"/>
+<pin name="PC6" x="33.02" y="-10.16" length="short" rot="R180"/>
+<pin name="PC7" x="33.02" y="-7.62" length="short" rot="R180"/>
+<pin name="PC8" x="33.02" y="-5.08" length="short" rot="R180"/>
+<pin name="PC9" x="33.02" y="-2.54" length="short" rot="R180"/>
+<pin name="PA8" x="33.02" y="0" length="short" rot="R180"/>
+<pin name="PA9" x="33.02" y="2.54" length="short" rot="R180"/>
+<pin name="PA10" x="33.02" y="5.08" length="short" rot="R180"/>
+<pin name="PA11" x="33.02" y="7.62" length="short" rot="R180"/>
+<pin name="PA12" x="33.02" y="10.16" length="short" rot="R180"/>
+<pin name="PA13" x="33.02" y="12.7" length="short" rot="R180"/>
+<pin name="VSS2" x="33.02" y="15.24" length="short" direction="sup" rot="R180"/>
+<pin name="VDD2" x="33.02" y="17.78" length="short" direction="sup" rot="R180"/>
+<pin name="PA14" x="20.32" y="30.48" length="short" rot="R270"/>
+<pin name="PA15" x="17.78" y="30.48" length="short" rot="R270"/>
+<pin name="PC10" x="15.24" y="30.48" length="short" rot="R270"/>
+<pin name="PC11" x="12.7" y="30.48" length="short" rot="R270"/>
+<pin name="PC12" x="10.16" y="30.48" length="short" rot="R270"/>
+<pin name="PD2" x="7.62" y="30.48" length="short" rot="R270"/>
+<pin name="PB3" x="5.08" y="30.48" length="short" rot="R270"/>
+<pin name="PB4" x="2.54" y="30.48" length="short" rot="R270"/>
+<pin name="PB5" x="0" y="30.48" length="short" rot="R270"/>
+<pin name="PB6" x="-2.54" y="30.48" length="short" rot="R270"/>
+<pin name="PB7" x="-5.08" y="30.48" length="short" rot="R270"/>
+<pin name="BOOT0" x="-7.62" y="30.48" length="short" direction="in" rot="R270"/>
+<pin name="PB8" x="-10.16" y="30.48" length="short" rot="R270"/>
+<pin name="PB9" x="-12.7" y="30.48" length="short" rot="R270"/>
+<pin name="VSS3" x="-15.24" y="30.48" length="short" direction="sup" rot="R270"/>
+<pin name="VDD3" x="-17.78" y="30.48" length="short" direction="sup" rot="R270"/>
+<wire x1="-27.94" y1="27.94" x2="-27.94" y2="-30.48" width="0.254" layer="94"/>
+<wire x1="-27.94" y1="-30.48" x2="30.48" y2="-30.48" width="0.254" layer="94"/>
+<wire x1="30.48" y1="-30.48" x2="30.48" y2="27.94" width="0.254" layer="94"/>
+<wire x1="30.48" y1="27.94" x2="-27.94" y2="27.94" width="0.254" layer="94"/>
+<text x="-27.94" y="27.94" size="1.778" layer="95">&gt;NAME</text>
+<text x="-27.94" y="-30.48" size="1.778" layer="96" align="top-left">&gt;MPN</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -18931,6 +19077,89 @@ Isolated Flyback Converter with 630V/300mA Switch
 <technology name="">
 <attribute name="MANUFACTURER" value="BINDER" constant="no"/>
 <attribute name="MPN" value="M12-A- 763" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="STM32-LQFP64" prefix="U">
+<gates>
+<gate name="G$1" symbol="STM32-SYMBOL" x="27.94" y="-27.94"/>
+</gates>
+<devices>
+<device name="" package="STM32-FOOTPRINT">
+<connects>
+<connect gate="G$1" pin="BOOT0" pad="P$60"/>
+<connect gate="G$1" pin="NRST" pad="P$7"/>
+<connect gate="G$1" pin="PA0" pad="P$14"/>
+<connect gate="G$1" pin="PA1" pad="P$15"/>
+<connect gate="G$1" pin="PA10" pad="P$43"/>
+<connect gate="G$1" pin="PA11" pad="P$44"/>
+<connect gate="G$1" pin="PA12" pad="P$45"/>
+<connect gate="G$1" pin="PA13" pad="P$46"/>
+<connect gate="G$1" pin="PA14" pad="P$49"/>
+<connect gate="G$1" pin="PA15" pad="P$50"/>
+<connect gate="G$1" pin="PA2" pad="P$16"/>
+<connect gate="G$1" pin="PA3" pad="P$17"/>
+<connect gate="G$1" pin="PA4" pad="P$20"/>
+<connect gate="G$1" pin="PA5" pad="P$21"/>
+<connect gate="G$1" pin="PA6" pad="P$22"/>
+<connect gate="G$1" pin="PA7" pad="P$23"/>
+<connect gate="G$1" pin="PA8" pad="P$41"/>
+<connect gate="G$1" pin="PA9" pad="P$42"/>
+<connect gate="G$1" pin="PB0" pad="P$26"/>
+<connect gate="G$1" pin="PB1" pad="P$27"/>
+<connect gate="G$1" pin="PB10" pad="P$29"/>
+<connect gate="G$1" pin="PB12" pad="P$33"/>
+<connect gate="G$1" pin="PB13" pad="P$34"/>
+<connect gate="G$1" pin="PB14" pad="P$35"/>
+<connect gate="G$1" pin="PB15" pad="P$36"/>
+<connect gate="G$1" pin="PB2" pad="P$28"/>
+<connect gate="G$1" pin="PB3" pad="P$55"/>
+<connect gate="G$1" pin="PB4" pad="P$56"/>
+<connect gate="G$1" pin="PB5" pad="P$57"/>
+<connect gate="G$1" pin="PB6" pad="P$58"/>
+<connect gate="G$1" pin="PB7" pad="P$59"/>
+<connect gate="G$1" pin="PB8" pad="P$61"/>
+<connect gate="G$1" pin="PB9" pad="P$62"/>
+<connect gate="G$1" pin="PC0" pad="P$8"/>
+<connect gate="G$1" pin="PC1" pad="P$9"/>
+<connect gate="G$1" pin="PC10" pad="P$51"/>
+<connect gate="G$1" pin="PC11" pad="P$52"/>
+<connect gate="G$1" pin="PC12" pad="P$53"/>
+<connect gate="G$1" pin="PC13" pad="P$2"/>
+<connect gate="G$1" pin="PC14-OSC32_IN" pad="P$3"/>
+<connect gate="G$1" pin="PC15-OSC32_OUT" pad="P$4"/>
+<connect gate="G$1" pin="PC2" pad="P$10"/>
+<connect gate="G$1" pin="PC3" pad="P$11"/>
+<connect gate="G$1" pin="PC4" pad="P$24"/>
+<connect gate="G$1" pin="PC5" pad="P$25"/>
+<connect gate="G$1" pin="PC6" pad="P$37"/>
+<connect gate="G$1" pin="PC7" pad="P$38"/>
+<connect gate="G$1" pin="PC8" pad="P$39"/>
+<connect gate="G$1" pin="PC9" pad="P$40"/>
+<connect gate="G$1" pin="PD2" pad="P$54"/>
+<connect gate="G$1" pin="PH0-OSC_IN" pad="P$5"/>
+<connect gate="G$1" pin="PH1-OSC_OUT" pad="P$6"/>
+<connect gate="G$1" pin="VBAT" pad="P$1"/>
+<connect gate="G$1" pin="VCAP_1" pad="P$30"/>
+<connect gate="G$1" pin="VDD" pad="P$19"/>
+<connect gate="G$1" pin="VDD1" pad="P$32"/>
+<connect gate="G$1" pin="VDD2" pad="P$48"/>
+<connect gate="G$1" pin="VDD3" pad="P$64"/>
+<connect gate="G$1" pin="VDDA/VREF+" pad="P$13"/>
+<connect gate="G$1" pin="VSS" pad="P$18"/>
+<connect gate="G$1" pin="VSS1" pad="P$31"/>
+<connect gate="G$1" pin="VSS2" pad="P$47"/>
+<connect gate="G$1" pin="VSS3" pad="P$63"/>
+<connect gate="G$1" pin="VSSA/VREF-" pad="P$12"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DKPN" value="497-15376-ND" constant="no"/>
+<attribute name="MANUFACTURER" value="STMicroelectronics" constant="no"/>
+<attribute name="MOPN" value="511-STM32F446RET6" constant="no"/>
+<attribute name="MPN" value="STM32F446RET6" constant="no"/>
 </technology>
 </technologies>
 </device>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -19156,10 +19156,10 @@ Isolated Flyback Converter with 630V/300mA Switch
 </connects>
 <technologies>
 <technology name="">
-<attribute name="DKPN" value="497-15376-ND" constant="no"/>
-<attribute name="MANUFACTURER" value="STMicroelectronics" constant="no"/>
-<attribute name="MOPN" value="511-STM32F446RET6" constant="no"/>
-<attribute name="MPN" value="STM32F446RET6" constant="no"/>
+<attribute name="DKPN" value="497-15376-ND"/>
+<attribute name="MANUFACTURER" value="STMicroelectronics"/>
+<attribute name="MOPN" value="511-STM32F446RET6"/>
+<attribute name="MPN" value="STM32F446RET6"/>
 </technology>
 </technologies>
 </device>


### PR DESCRIPTION
STM32-LQFP64

# Pull Request (PR) into Circuits-Support-2024


## Part Description
Made the symbol, footprint and device for STM32-LQFP64. The symbol was made using the pins tool and the pins were setup according to the pin type and its function. The footprint was made according to the dimensions in the data sheet. Then the device was made by connecting the pins according to the order given. The data sheet has been provided in EAGLE.


## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?
