### PR TITLE
Added 1206-Diode footprint and SD1206S040S2R0 Device

### DIFF
--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="16" fill="1" visible="yes" active="yes"/>
@@ -191,10 +191,59 @@
 </layers>
 <library>
 <packages>
+<package name="1206-DIODE">
+<smd name="1" x="-1.497" y="0.019" dx="1" dy="1.5" layer="1"/>
+<smd name="2" x="1.541" y="0.011" dx="1" dy="1.5" layer="1"/>
+<wire x1="-0.959" y1="0.811" x2="1.041" y2="0.811" width="0.127" layer="21"/>
+<wire x1="1.041" y1="0.811" x2="1.041" y2="-0.789" width="0.127" layer="21"/>
+<wire x1="1.041" y1="-0.789" x2="-0.959" y2="-0.789" width="0.127" layer="21"/>
+<wire x1="-0.959" y1="-0.789" x2="-0.959" y2="0.811" width="0.127" layer="21"/>
+<rectangle x1="-2.54" y1="-1.27" x2="2.54" y2="1.27" layer="39"/>
+</package>
 </packages>
 <symbols>
+<symbol name="DIODE_SCHOTTKY">
+<wire x1="0" y1="1.27" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-1.27" width="0.1524" layer="94"/>
+<pin name="A" x="-5.08" y="0" visible="off" length="short" direction="pas"/>
+<pin name="C" x="2.54" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+<text x="-1.27" y="1.905" size="1.27" layer="95" align="bottom-center">&gt;NAME</text>
+<text x="-2.54" y="0" size="0.4064" layer="99" align="center">SpiceOrder 1</text>
+<text x="2.54" y="0" size="0.4064" layer="99" align="center">SpiceOrder 2</text>
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="-2.54" y2="1.27" width="0.1524" layer="94"/>
+<wire x1="0" y1="1.27" x2="-0.508" y2="1.27" width="0.1524" layer="94"/>
+<wire x1="-0.508" y1="1.27" x2="-0.508" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="0" y1="-1.27" x2="0.508" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="0.508" y1="-1.27" x2="0.508" y2="-1.016" width="0.1524" layer="94"/>
+</symbol>
 </symbols>
 <devicesets>
+<deviceset name="SD1206S040S2R0">
+<description>SD1206S040S2R0 
+&lt;a href = "https://datasheets.kyocera-avx.com/schottky.pdf"&gt; Datasheet&lt;\a&gt;</description>
+<gates>
+<gate name="G$1" symbol="DIODE_SCHOTTKY" x="5.08" y="0"/>
+</gates>
+<devices>
+<device name="" package="1206-DIODE">
+<connects>
+<connect gate="G$1" pin="A" pad="1"/>
+<connect gate="G$1" pin="C" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DKPN" value="478-7806-1-ND"/>
+<attribute name="MANUFACTURER" value="KYOCERA AVX"/>
+<attribute name="MOPN" value="581-SD1206S040S2R0"/>
+<attribute name="MPN" value="SD1206S040S2R0"/>
+<attribute name="VOLTAGE" value="40 V" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 </drawing>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024


## Part Description
Added 1206-Diode footprint and SD1206S040S2R0 device

## Additional Information
Datasheet: https://datasheets.kyocera-avx.com/schottky.pdf
Digikey Link: https://www.digikey.at/en/products/detail/kyocera-avx/SD1206S040S2R0/3749537

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?
