### PR TITLE
Max3074 eesa+

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -10875,6 +10875,22 @@ Isolated Flyback Converter with 630V/300mA Switch
 <wire x1="0" y1="0" x2="17.78" y2="0" width="0.254" layer="94"/>
 <wire x1="17.78" y1="0" x2="17.78" y2="-27.94" width="0.254" layer="94"/>
 <wire x1="17.78" y1="-27.94" x2="0" y2="-27.94" width="0.254" layer="94"/>
+</symbol>
+<symbol name="MAX3071E">
+<pin name="VCC" x="-5.08" y="20.32" length="middle" direction="pas"/>
+<pin name="RO" x="-5.08" y="15.24" length="middle" direction="pas"/>
+<pin name="DI" x="-5.08" y="10.16" length="middle" direction="pas"/>
+<pin name="GND" x="-5.08" y="5.08" length="middle" direction="pas"/>
+<pin name="Y" x="30.48" y="5.08" length="middle" direction="pas" rot="R180"/>
+<pin name="Z" x="30.48" y="10.16" length="middle" direction="pas" rot="R180"/>
+<pin name="B" x="30.48" y="15.24" length="middle" direction="pas" rot="R180"/>
+<pin name="A" x="30.48" y="20.32" length="middle" direction="pas" rot="R180"/>
+<wire x1="0" y1="0" x2="0" y2="25.4" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="25.4" y2="0" width="0.254" layer="94"/>
+<wire x1="25.4" y1="0" x2="25.4" y2="25.4" width="0.254" layer="94"/>
+<wire x1="25.4" y1="25.4" x2="0" y2="25.4" width="0.254" layer="94"/>
+<text x="0" y="25.4" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="0" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
 </symbol>
 </symbols>
 <devicesets>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -10892,6 +10892,22 @@ Isolated Flyback Converter with 630V/300mA Switch
 <text x="0" y="25.4" size="1.778" layer="95">&gt;NAME</text>
 <text x="0" y="0" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
 </symbol>
+<symbol name="MAX3074EESA+">
+<pin name="VCC" x="-5.08" y="20.32" length="middle" direction="pas"/>
+<pin name="RO" x="-5.08" y="15.24" length="middle" direction="pas"/>
+<pin name="DI" x="-5.08" y="10.16" length="middle" direction="pas"/>
+<pin name="GND" x="-5.08" y="5.08" length="middle" direction="pas"/>
+<pin name="Y" x="27.94" y="5.08" length="middle" direction="pas" rot="R180"/>
+<pin name="Z" x="27.94" y="10.16" length="middle" direction="pas" rot="R180"/>
+<pin name="B" x="27.94" y="15.24" length="middle" direction="pas" rot="R180"/>
+<pin name="A" x="27.94" y="20.32" length="middle" direction="pas" rot="R180"/>
+<wire x1="0" y1="0" x2="0" y2="22.86" width="0.254" layer="94"/>
+<wire x1="0" y1="22.86" x2="22.86" y2="22.86" width="0.254" layer="94"/>
+<wire x1="22.86" y1="22.86" x2="22.86" y2="0" width="0.254" layer="94"/>
+<wire x1="22.86" y1="0" x2="0" y2="0" width="0.254" layer="94"/>
+<text x="0" y="22.86" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="0" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="CONNECTOR-2_?_*" prefix="J">
@@ -18737,6 +18753,36 @@ Isolated Flyback Converter with 630V/300mA Switch
 <attribute name="MANUFACTURER" value="GCT"/>
 <attribute name="MOPN" value="640-USB4110-GF-A"/>
 <attribute name="MPN" value="USB4110 "/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MAX3074EESA+" prefix="U">
+<description>Maxim Integrated MAX3074EESA+ 
+&lt;br&gt;
+&lt;a href="https://www.mouser.com/datasheet/2/609/MAX3070E_MAX3079E-3128184.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="MAX3074EESA+" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOIC-08(NARROW,0.15&quot;)">
+<connects>
+<connect gate="G$1" pin="A" pad="8"/>
+<connect gate="G$1" pin="B" pad="7"/>
+<connect gate="G$1" pin="DI" pad="3"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="RO" pad="2"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
+<connect gate="G$1" pin="Y" pad="5"/>
+<connect gate="G$1" pin="Z" pad="6"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DKPN" value="MAX3074EESA+-ND " constant="no"/>
+<attribute name="MANUFACTURER" value="Maxim Integrated" constant="no"/>
+<attribute name="MOPN" value="700-MAX3074EESA" constant="no"/>
+<attribute name="MPN" value="MAX3074EESA+" constant="no"/>
 </technology>
 </technologies>
 </device>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -415,6 +415,26 @@
 <hole x="2.89" y="-0.5" drill="0.65"/>
 <rectangle x1="-6.5" y1="-6.78" x2="6.5" y2="1.5" layer="39"/>
 </package>
+<package name="SOIC-08(NARROW,0.15&quot;)">
+<description>SOIC-8
+&lt;br&gt;
+&lt;a href="https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/ltc-legacy-soic/05081610_G_SO8.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<smd name="2" x="-0.635" y="-2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="7" x="-0.635" y="2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="1" x="-1.905" y="-2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="3" x="0.635" y="-2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="4" x="1.905" y="-2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="8" x="-1.905" y="2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="6" x="0.635" y="2.6035" dx="0.762" dy="1.143" layer="1"/>
+<smd name="5" x="1.905" y="2.6035" dx="0.762" dy="1.143" layer="1"/>
+<text x="-3.175" y="0" size="0.8128" layer="25" font="vector" rot="R90" align="bottom-center">&gt;NAME</text>
+<wire x1="-2.5019" y1="1.9939" x2="2.5019" y2="1.9939" width="0.127" layer="21"/>
+<wire x1="2.5019" y1="1.9939" x2="2.5019" y2="-1.9939" width="0.127" layer="21"/>
+<wire x1="2.5019" y1="-1.9939" x2="-2.5019" y2="-1.9939" width="0.127" layer="21"/>
+<wire x1="-2.5019" y1="-1.9939" x2="-2.5019" y2="1.9939" width="0.127" layer="21"/>
+<rectangle x1="-2.794" y1="-3.556" x2="2.794" y2="3.556" layer="39"/>
+<circle x="-3.175" y="-2.54" radius="0.254" width="0" layer="21"/>
+</package>
 </packages>
 <symbols>
 <symbol name="USB4500-03-0-A">
@@ -462,6 +482,22 @@
 <wire x1="0" y1="0" x2="17.78" y2="0" width="0.254" layer="94"/>
 <wire x1="17.78" y1="0" x2="17.78" y2="-27.94" width="0.254" layer="94"/>
 <wire x1="17.78" y1="-27.94" x2="0" y2="-27.94" width="0.254" layer="94"/>
+</symbol>
+<symbol name="MAX3074EESA+">
+<pin name="VCC" x="-5.08" y="20.32" length="middle" direction="pas"/>
+<pin name="RO" x="-5.08" y="15.24" length="middle" direction="pas"/>
+<pin name="DI" x="-5.08" y="10.16" length="middle" direction="pas"/>
+<pin name="GND" x="-5.08" y="5.08" length="middle" direction="pas"/>
+<pin name="Y" x="27.94" y="5.08" length="middle" direction="pas" rot="R180"/>
+<pin name="Z" x="27.94" y="10.16" length="middle" direction="pas" rot="R180"/>
+<pin name="B" x="27.94" y="15.24" length="middle" direction="pas" rot="R180"/>
+<pin name="A" x="27.94" y="20.32" length="middle" direction="pas" rot="R180"/>
+<wire x1="0" y1="0" x2="0" y2="22.86" width="0.254" layer="94"/>
+<wire x1="0" y1="22.86" x2="22.86" y2="22.86" width="0.254" layer="94"/>
+<wire x1="22.86" y1="22.86" x2="22.86" y2="0" width="0.254" layer="94"/>
+<wire x1="22.86" y1="0" x2="0" y2="0" width="0.254" layer="94"/>
+<text x="0" y="22.86" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="0" size="1.778" layer="96" align="top-left">&gt;VALUE</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -529,6 +565,31 @@
 <attribute name="MOPN" value="640-USB4110-GF-A"/>
 <attribute name="MPN" value="USB4110 "/>
 </technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MAX3074EESA+">
+<description>ADI MAX3074EESA+ 
+
+&lt;a href="https://www.mouser.com/datasheet/2/609/MAX3070E_MAX3079E-3128184.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="MAX3074EESA+" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOIC-08(NARROW,0.15&quot;)">
+<connects>
+<connect gate="G$1" pin="A" pad="8"/>
+<connect gate="G$1" pin="B" pad="7"/>
+<connect gate="G$1" pin="DI" pad="3"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="RO" pad="2"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
+<connect gate="G$1" pin="Y" pad="5"/>
+<connect gate="G$1" pin="Z" pad="6"/>
+</connects>
+<technologies>
+<technology name=""/>
 </technologies>
 </device>
 </devices>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -191,230 +191,6 @@
 </layers>
 <library>
 <packages>
-<package name="USB4500-03-0-A">
-<description>USB4500 USB-C Connector
-&lt;br&gt;
-&lt;b&gt;&lt;a href="https://gct.co/files/drawings/usb4500.pdf"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<circle x="3.08" y="0.381" radius="0.1" width="0.2" layer="21"/>
-<wire x1="1.88" y1="-7.569" x2="10.82" y2="-7.569" width="0.2" layer="21"/>
-<wire x1="1.88" y1="-8.069" x2="1.88" y2="-1.569" width="0.1" layer="51"/>
-<wire x1="10.82" y1="-8.069" x2="10.82" y2="-1.569" width="0.1" layer="51"/>
-<wire x1="1.88" y1="-1.569" x2="10.82" y2="-1.569" width="0.1" layer="51"/>
-<wire x1="1.88" y1="-8.069" x2="10.82" y2="-8.069" width="0.1" layer="51"/>
-<wire x1="-0.02" y1="-8.319" x2="-0.02" y2="-0.019" width="0.05" layer="39"/>
-<wire x1="-0.02" y1="-8.319" x2="12.72" y2="-8.319" width="0.05" layer="39"/>
-<wire x1="-0.02" y1="-0.019" x2="12.72" y2="-0.019" width="0.05" layer="39"/>
-<wire x1="12.72" y1="-8.319" x2="12.72" y2="-0.019" width="0.05" layer="39"/>
-<text x="12.81" y="-7.459" size="0.8128" layer="51" ratio="15" rot="SR0">PCB Edge</text>
-<text x="0.8" y="2.441" size="1.27" layer="25" ratio="13" rot="SR0">&gt;NAME</text>
-<text x="0.9" y="0.781" size="1.27" layer="27" ratio="13" rot="SR0">&gt;VALUE</text>
-<circle x="3.08" y="0.381" radius="0.1" width="0.2" layer="51"/>
-<wire x1="0.35" y1="-7.569" x2="12.35" y2="-7.569" width="0.1" layer="51"/>
-<wire x1="0.43" y1="-5.369" x2="0.73" y2="-5.069" width="0" layer="46" curve="-90"/>
-<wire x1="0.73" y1="-5.069" x2="1.03" y2="-5.369" width="0" layer="46" curve="-90"/>
-<wire x1="1.03" y1="-5.369" x2="1.03" y2="-6.569" width="0" layer="46"/>
-<wire x1="1.03" y1="-6.569" x2="0.73" y2="-6.869" width="0" layer="46" curve="-90"/>
-<wire x1="0.73" y1="-6.869" x2="0.43" y2="-6.569" width="0" layer="46" curve="-90"/>
-<wire x1="0.43" y1="-6.569" x2="0.43" y2="-5.369" width="0" layer="46"/>
-<wire x1="-0.17" y1="-7.569" x2="1.73" y2="-7.569" width="0" layer="46"/>
-<wire x1="1.73" y1="-7.569" x2="1.73" y2="-1.369" width="0" layer="46"/>
-<wire x1="1.73" y1="-1.369" x2="2.055" y2="-0.969" width="0" layer="46" curve="-90"/>
-<wire x1="2.055" y1="-0.969" x2="2.38" y2="-1.249" width="0" layer="46" curve="-90"/>
-<wire x1="2.38" y1="-1.249" x2="2.53" y2="-1.369" width="0" layer="46" curve="90"/>
-<wire x1="2.53" y1="-1.369" x2="10.17" y2="-1.369" width="0" layer="46"/>
-<wire x1="10.32" y1="-1.249" x2="10.17" y2="-1.369" width="0" layer="46" curve="-90"/>
-<wire x1="10.32" y1="-1.249" x2="10.645" y2="-0.969" width="0" layer="46" curve="-90"/>
-<wire x1="10.645" y1="-0.969" x2="10.97" y2="-1.369" width="0" layer="46" curve="-90"/>
-<wire x1="10.97" y1="-1.369" x2="10.97" y2="-7.569" width="0" layer="46"/>
-<wire x1="10.97" y1="-7.569" x2="12.71" y2="-7.569" width="0" layer="46"/>
-<wire x1="11.67" y1="-1.569" x2="11.97" y2="-1.269" width="0" layer="46" curve="-90"/>
-<wire x1="11.97" y1="-1.269" x2="12.27" y2="-1.569" width="0" layer="46" curve="-90"/>
-<wire x1="12.27" y1="-1.569" x2="12.27" y2="-2.369" width="0" layer="46"/>
-<wire x1="12.27" y1="-2.369" x2="11.97" y2="-2.669" width="0" layer="46" curve="-90"/>
-<wire x1="11.97" y1="-2.669" x2="11.67" y2="-2.369" width="0" layer="46" curve="-90"/>
-<wire x1="11.67" y1="-2.369" x2="11.67" y2="-1.569" width="0" layer="46"/>
-<polygon width="0.01" layer="29">
-<vertex x="11.37" y="-2.369"/>
-<vertex x="11.37" y="-1.569" curve="-90"/>
-<vertex x="11.97" y="-0.969" curve="-90"/>
-<vertex x="12.57" y="-1.569"/>
-<vertex x="12.57" y="-2.369" curve="-90"/>
-<vertex x="11.97" y="-2.969" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="30">
-<vertex x="11.37" y="-2.369"/>
-<vertex x="11.37" y="-1.569" curve="-90"/>
-<vertex x="11.97" y="-0.969" curve="-90"/>
-<vertex x="12.57" y="-1.569"/>
-<vertex x="12.57" y="-2.369" curve="-90"/>
-<vertex x="11.97" y="-2.969" curve="-90"/>
-</polygon>
-<wire x1="0.43" y1="-1.569" x2="0.73" y2="-1.269" width="0" layer="46" curve="-90"/>
-<wire x1="0.73" y1="-1.269" x2="1.03" y2="-1.569" width="0" layer="46" curve="-90"/>
-<wire x1="1.03" y1="-1.569" x2="1.03" y2="-2.369" width="0" layer="46"/>
-<wire x1="1.03" y1="-2.369" x2="0.73" y2="-2.669" width="0" layer="46" curve="-90"/>
-<wire x1="0.73" y1="-2.669" x2="0.43" y2="-2.369" width="0" layer="46" curve="-90"/>
-<wire x1="0.43" y1="-2.369" x2="0.43" y2="-1.569" width="0" layer="46"/>
-<polygon width="0.01" layer="29">
-<vertex x="0.13" y="-2.369"/>
-<vertex x="0.13" y="-1.569" curve="-90"/>
-<vertex x="0.73" y="-0.969" curve="-90"/>
-<vertex x="1.33" y="-1.569"/>
-<vertex x="1.33" y="-2.369" curve="-90"/>
-<vertex x="0.73" y="-2.969" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="30">
-<vertex x="0.13" y="-2.369"/>
-<vertex x="0.13" y="-1.569" curve="-90"/>
-<vertex x="0.73" y="-0.969" curve="-90"/>
-<vertex x="1.33" y="-1.569"/>
-<vertex x="1.33" y="-2.369" curve="-90"/>
-<vertex x="0.73" y="-2.969" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="29">
-<vertex x="0.13" y="-6.569"/>
-<vertex x="0.13" y="-5.369" curve="-90"/>
-<vertex x="0.73" y="-4.769" curve="-90"/>
-<vertex x="1.33" y="-5.369"/>
-<vertex x="1.33" y="-6.569" curve="-90"/>
-<vertex x="0.73" y="-7.169" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="30">
-<vertex x="0.13" y="-6.569"/>
-<vertex x="0.13" y="-5.369" curve="-90"/>
-<vertex x="0.73" y="-4.769" curve="-90"/>
-<vertex x="1.33" y="-5.369"/>
-<vertex x="1.33" y="-6.569" curve="-90"/>
-<vertex x="0.73" y="-7.169" curve="-90"/>
-</polygon>
-<wire x1="11.67" y1="-5.369" x2="11.97" y2="-5.069" width="0" layer="46" curve="-90"/>
-<wire x1="11.97" y1="-5.069" x2="12.27" y2="-5.369" width="0" layer="46" curve="-90"/>
-<wire x1="12.27" y1="-5.369" x2="12.27" y2="-6.569" width="0" layer="46"/>
-<wire x1="12.27" y1="-6.569" x2="11.97" y2="-6.869" width="0" layer="46" curve="-90"/>
-<wire x1="11.97" y1="-6.869" x2="11.67" y2="-6.569" width="0" layer="46" curve="-90"/>
-<wire x1="11.67" y1="-6.569" x2="11.67" y2="-5.369" width="0" layer="46"/>
-<polygon width="0.01" layer="29">
-<vertex x="11.37" y="-6.569"/>
-<vertex x="11.37" y="-5.369" curve="-90"/>
-<vertex x="11.97" y="-4.769" curve="-90"/>
-<vertex x="12.57" y="-5.369"/>
-<vertex x="12.57" y="-6.569" curve="-90"/>
-<vertex x="11.97" y="-7.169" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="30">
-<vertex x="11.37" y="-6.569"/>
-<vertex x="11.37" y="-5.369" curve="-90"/>
-<vertex x="11.97" y="-4.769" curve="-90"/>
-<vertex x="12.57" y="-5.369"/>
-<vertex x="12.57" y="-6.569" curve="-90"/>
-<vertex x="11.97" y="-7.169" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="1">
-<vertex x="0.73" y="-2.869" curve="-90"/>
-<vertex x="0.23" y="-2.369"/>
-<vertex x="0.23" y="-1.569" curve="-90"/>
-<vertex x="0.73" y="-1.069" curve="-90"/>
-<vertex x="1.23" y="-1.569"/>
-<vertex x="1.23" y="-2.369" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="1">
-<vertex x="11.97" y="-2.869" curve="-90"/>
-<vertex x="11.47" y="-2.369"/>
-<vertex x="11.47" y="-1.569" curve="-90"/>
-<vertex x="11.97" y="-1.069" curve="-90"/>
-<vertex x="12.47" y="-1.569"/>
-<vertex x="12.47" y="-2.369" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="16">
-<vertex x="0.73" y="-2.869" curve="-90"/>
-<vertex x="0.23" y="-2.369"/>
-<vertex x="0.23" y="-1.569" curve="-90"/>
-<vertex x="0.73" y="-1.069" curve="-90"/>
-<vertex x="1.23" y="-1.569"/>
-<vertex x="1.23" y="-2.369" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="16">
-<vertex x="11.97" y="-2.869" curve="-90"/>
-<vertex x="11.47" y="-2.369"/>
-<vertex x="11.47" y="-1.569" curve="-90"/>
-<vertex x="11.97" y="-1.069" curve="-90"/>
-<vertex x="12.47" y="-1.569"/>
-<vertex x="12.47" y="-2.369" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="16">
-<vertex x="11.97" y="-7.069" curve="-90"/>
-<vertex x="11.47" y="-6.569"/>
-<vertex x="11.47" y="-5.369" curve="-90"/>
-<vertex x="11.97" y="-4.869" curve="-90"/>
-<vertex x="12.47" y="-5.369"/>
-<vertex x="12.47" y="-6.569" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="1">
-<vertex x="0.73" y="-7.069" curve="-90"/>
-<vertex x="0.23" y="-6.569"/>
-<vertex x="0.23" y="-5.369" curve="-90"/>
-<vertex x="0.73" y="-4.869" curve="-90"/>
-<vertex x="1.23" y="-5.369"/>
-<vertex x="1.23" y="-6.569" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="1">
-<vertex x="11.97" y="-7.069" curve="-90"/>
-<vertex x="11.47" y="-6.569"/>
-<vertex x="11.47" y="-5.369" curve="-90"/>
-<vertex x="11.97" y="-4.869" curve="-90"/>
-<vertex x="12.47" y="-5.369"/>
-<vertex x="12.47" y="-6.569" curve="-90"/>
-</polygon>
-<polygon width="0.01" layer="16">
-<vertex x="0.73" y="-7.069" curve="-90"/>
-<vertex x="0.23" y="-6.569"/>
-<vertex x="0.23" y="-5.369" curve="-90"/>
-<vertex x="0.73" y="-4.869" curve="-90"/>
-<vertex x="1.23" y="-5.369"/>
-<vertex x="1.23" y="-6.569" curve="-90"/>
-</polygon>
-<smd name="A1_B12" x="3.15" y="-0.819" dx="0.6" dy="1.1" layer="1"/>
-<smd name="A4_B9" x="3.95" y="-0.819" dx="0.6" dy="1.1" layer="1"/>
-<smd name="B8" x="4.6" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="A5" x="5.1" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="B7" x="5.6" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="A6" x="6.1" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="A7" x="6.6" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="B6" x="7.1" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="A8" x="7.6" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="B5" x="8.1" y="-0.819" dx="0.3" dy="1.1" layer="1"/>
-<smd name="B4_A9" x="8.75" y="-0.819" dx="0.6" dy="1.1" layer="1"/>
-<smd name="B1_A12" x="9.55" y="-0.819" dx="0.6" dy="1.1" layer="1"/>
-<pad name="S1" x="0.73" y="-5.969" drill="0.6" diameter="0.95" shape="long" rot="R270" stop="no"/>
-<pad name="S2" x="11.97" y="-1.969" drill="0.6" diameter="0.8" shape="long" rot="R270" stop="no"/>
-<pad name="S3" x="0.73" y="-1.969" drill="0.6" diameter="0.8" shape="long" rot="R270" stop="no"/>
-<pad name="S4" x="11.97" y="-5.969" drill="0.6" diameter="0.95" shape="long" rot="R270" stop="no"/>
-</package>
-<package name="USB4110">
-<description>USB4110
-
-&lt;br&gt;
-&lt;b&gt;&lt;a href="https://gct.co/Files/Drawings/USB4110.pdf?v=9c3521e1-ea1e-4753-bd59-adae5023b7f4"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<smd name="S$1" x="-5.11" y="0" dx="2.18" dy="2" layer="1"/>
-<smd name="S$3" x="-5.11" y="-3.93" dx="2.18" dy="2" layer="1"/>
-<smd name="S$2" x="5.11" y="0" dx="2.18" dy="2" layer="1"/>
-<smd name="S$4" x="5.11" y="-3.93" dx="2.18" dy="2" layer="1"/>
-<smd name="P$1" x="-3.2" y="0.6" dx="0.6" dy="1.15" layer="1"/>
-<smd name="P$2" x="-2.4" y="0.6" dx="0.6" dy="1.15" layer="1"/>
-<smd name="P$3" x="-1.75" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$4" x="-1.25" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$5" x="-0.75" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$6" x="-0.25" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$7" x="0.25" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$8" x="0.75" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$9" x="1.25" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$10" x="1.75" y="0.6" dx="0.3" dy="1.15" layer="1"/>
-<smd name="P$11" x="2.4" y="0.6" dx="0.6" dy="1.15" layer="1"/>
-<smd name="P$12" x="3.2" y="0.6" dx="0.6" dy="1.15" layer="1"/>
-<hole x="-2.89" y="-0.5" drill="0.65"/>
-<hole x="2.89" y="-0.5" drill="0.65"/>
-<rectangle x1="-6.5" y1="-6.78" x2="6.5" y2="1.5" layer="39"/>
-</package>
 <package name="SOIC-08(NARROW,0.15&quot;)">
 <description>SOIC-8
 &lt;br&gt;
@@ -437,52 +213,6 @@
 </package>
 </packages>
 <symbols>
-<symbol name="USB4500-03-0-A">
-<description>USB4500 USB-C Connector, right angle, SMD
-&lt;br/&gt;
-&lt;b&gt;&lt;a href="https://gct.co/files/drawings/usb4500.pdf"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<wire x1="0" y1="0" x2="25.4" y2="0" width="0.254" layer="94"/>
-<wire x1="25.4" y1="0" x2="25.4" y2="-33.02" width="0.254" layer="94"/>
-<wire x1="25.4" y1="-33.02" x2="0" y2="-33.02" width="0.254" layer="94"/>
-<wire x1="0" y1="-33.02" x2="0" y2="0" width="0.254" layer="94"/>
-<text x="0" y="0.762" size="1.778" layer="95">&gt;NAME</text>
-<text x="0" y="-33.782" size="1.778" layer="96" rot="MR180">&gt;VALUE</text>
-<pin name="GND_A" x="-2.54" y="-25.4" length="short" direction="pwr"/>
-<pin name="VBUS_A" x="-2.54" y="-2.54" length="short" direction="pwr"/>
-<pin name="DP1" x="-2.54" y="-12.7" length="short"/>
-<pin name="CC1" x="-2.54" y="-10.16" length="short"/>
-<pin name="SBU1" x="-2.54" y="-17.78" length="short"/>
-<pin name="DN1" x="-2.54" y="-15.24" length="short"/>
-<pin name="SHELL_GND" x="27.94" y="-30.48" length="short" direction="pwr" rot="R180"/>
-<pin name="GND_B" x="27.94" y="-25.4" length="short" direction="pwr" rot="R180"/>
-<pin name="VBUS_B" x="27.94" y="-2.54" length="short" direction="pwr" rot="R180"/>
-<pin name="DP2" x="27.94" y="-15.24" length="short" rot="R180"/>
-<pin name="CC2" x="27.94" y="-17.78" length="short" rot="R180"/>
-<pin name="SBU2" x="27.94" y="-10.16" length="short" rot="R180"/>
-<pin name="DN2" x="27.94" y="-12.7" length="short" rot="R180"/>
-</symbol>
-<symbol name="USB4110">
-<description>USB4110
-
-&lt;br&gt;
-
-&lt;b&gt;&lt;a href="https://gct.co/files/drawings/usb4110.pdf?v=9c3521e1-ea1e-4753-bd59-adae5023b7f4"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<pin name="GND" x="22.86" y="-25.4" length="middle" direction="pwr" rot="R180"/>
-<pin name="VBUS" x="22.86" y="-2.54" length="middle" direction="pwr" rot="R180"/>
-<pin name="CC1" x="-5.08" y="-2.54" length="middle" direction="pas"/>
-<pin name="DP1" x="-5.08" y="-10.16" length="middle"/>
-<pin name="DN1" x="-5.08" y="-12.7" length="middle" function="dot"/>
-<pin name="SBU1" x="-5.08" y="-22.86" length="middle"/>
-<pin name="SBU2" x="-5.08" y="-25.4" length="middle"/>
-<pin name="DN2" x="-5.08" y="-17.78" length="middle" function="dot"/>
-<pin name="DP2" x="-5.08" y="-15.24" length="middle"/>
-<pin name="CC2" x="-5.08" y="-5.08" length="middle" direction="pas"/>
-<pin name="SHELL" x="22.86" y="-22.86" length="middle" direction="pwr" rot="R180"/>
-<wire x1="0" y1="-27.94" x2="0" y2="0" width="0.254" layer="94"/>
-<wire x1="0" y1="0" x2="17.78" y2="0" width="0.254" layer="94"/>
-<wire x1="17.78" y1="0" x2="17.78" y2="-27.94" width="0.254" layer="94"/>
-<wire x1="17.78" y1="-27.94" x2="0" y2="-27.94" width="0.254" layer="94"/>
-</symbol>
 <symbol name="MAX3074EESA+">
 <pin name="VCC" x="-5.08" y="20.32" length="middle" direction="pas"/>
 <pin name="RO" x="-5.08" y="15.24" length="middle" direction="pas"/>
@@ -501,77 +231,9 @@
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="USB4500-03-0-A" prefix="J">
-<description>USB4500 USB C Right Angle Connector
-&lt;br/&gt;
-&lt;b&gt;&lt;a href="https://gct.co/files/drawings/usb4500.pdf"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<gates>
-<gate name="G$1" symbol="USB4500-03-0-A" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="USB4500-03-0-A">
-<connects>
-<connect gate="G$1" pin="CC1" pad="A5"/>
-<connect gate="G$1" pin="CC2" pad="B5"/>
-<connect gate="G$1" pin="DN1" pad="A7"/>
-<connect gate="G$1" pin="DN2" pad="B7"/>
-<connect gate="G$1" pin="DP1" pad="A6"/>
-<connect gate="G$1" pin="DP2" pad="B6"/>
-<connect gate="G$1" pin="GND_A" pad="A1_B12"/>
-<connect gate="G$1" pin="GND_B" pad="B1_A12"/>
-<connect gate="G$1" pin="SBU1" pad="A8"/>
-<connect gate="G$1" pin="SBU2" pad="B8"/>
-<connect gate="G$1" pin="SHELL_GND" pad="S1 S2 S3 S4"/>
-<connect gate="G$1" pin="VBUS_A" pad="A4_B9"/>
-<connect gate="G$1" pin="VBUS_B" pad="B4_A9"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="DKPN" value="2073-USB4500-03-0-ATR-ND"/>
-<attribute name="MANUFACTURER" value="GCT"/>
-<attribute name="MOPN" value="640-USB4500030A"/>
-<attribute name="MPN" value="USB4500-03-0-A "/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="USB4110" prefix="J">
-<description>USB4110 USB-C Conenctor
+<deviceset name="MAX3074EESA+" prefix="U">
+<description>Maxim Integrated MAX3074EESA+ 
 &lt;br&gt;
-&lt;b&gt;&lt;a href="https://gct.co/Files/Drawings/USB4110.pdf?v=9c3521e1-ea1e-4753-bd59-adae5023b7f4"&gt;Datasheet&lt;/a&gt;&lt;/b&gt;</description>
-<gates>
-<gate name="G$1" symbol="USB4110" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="USB4110">
-<connects>
-<connect gate="G$1" pin="CC1" pad="P$4"/>
-<connect gate="G$1" pin="CC2" pad="P$10"/>
-<connect gate="G$1" pin="DN1" pad="P$7"/>
-<connect gate="G$1" pin="DN2" pad="P$5"/>
-<connect gate="G$1" pin="DP1" pad="P$6"/>
-<connect gate="G$1" pin="DP2" pad="P$8"/>
-<connect gate="G$1" pin="GND" pad="P$1 P$12" route="any"/>
-<connect gate="G$1" pin="SBU1" pad="P$9"/>
-<connect gate="G$1" pin="SBU2" pad="P$3"/>
-<connect gate="G$1" pin="SHELL" pad="S$1 S$2 S$3 S$4"/>
-<connect gate="G$1" pin="VBUS" pad="P$2 P$11"/>
-</connects>
-<technologies>
-<technology name="">
-<attribute name="DKPN" value="2073-USB4110-GF-A-1-ND"/>
-<attribute name="MANUFACTURER" value="GCT"/>
-<attribute name="MOPN" value="640-USB4110-GF-A"/>
-<attribute name="MPN" value="USB4110 "/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="MAX3074EESA+">
-<description>ADI MAX3074EESA+ 
-
 &lt;a href="https://www.mouser.com/datasheet/2/609/MAX3070E_MAX3079E-3128184.pdf"&gt;Datasheet&lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="MAX3074EESA+" x="0" y="0"/>
@@ -589,7 +251,13 @@
 <connect gate="G$1" pin="Z" pad="6"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DKPN" value="MAX3074EESA+-ND
+" constant="no"/>
+<attribute name="MANUFACTURER" value="Maxim Integrated" constant="no"/>
+<attribute name="MOPN" value="700-MAX3074EESA" constant="no"/>
+<attribute name="MPN" value="MAX3074EESA+" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
Added MAX3074EEAS+ Transceiver as a 3.3V output substitute for ADM4854
- Added device
- Added symbol

## Additional Information
Datasheet: https://www.mouser.com/datasheet/2/609/MAX3070E_MAX3079E-3128184.pdf

## Checklist
- [x ] Did you create any new schematics or boards?
- - [ x] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [ x] Did you pull `main` into your branch?
- - [ x] Did you *check for merge conflicts*?
- - [ x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x ] Did you fill out the above template?
- [x ] Did you assign the right people for review (on the right)?
- [ x] Did you comply with the library style guidelines?
