### PR TITLE
fixed naming

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -20348,21 +20348,21 @@ Requires ordering of:
 &lt;br&gt;
 Note: OPA2991 is also a comparator</description>
 <gates>
-<gate name="G$1" symbol="OPAMP" x="22.86" y="0"/>
-<gate name="G$2" symbol="PWR_GND" x="0" y="0"/>
-<gate name="G$3" symbol="OPAMP" x="22.86" y="-12.7"/>
+<gate name="A" symbol="OPAMP" x="22.86" y="0"/>
+<gate name="P" symbol="PWR_GND" x="0" y="0"/>
+<gate name="B" symbol="OPAMP" x="22.86" y="-12.7"/>
 </gates>
 <devices>
 <device name="OPA_2991" package="SOT-23-8">
 <connects>
-<connect gate="G$1" pin="VIN+" pad="3"/>
-<connect gate="G$1" pin="VIN-" pad="2"/>
-<connect gate="G$1" pin="VOUT" pad="1"/>
-<connect gate="G$2" pin="GND" pad="4"/>
-<connect gate="G$2" pin="VDD" pad="8"/>
-<connect gate="G$3" pin="VIN+" pad="5"/>
-<connect gate="G$3" pin="VIN-" pad="6"/>
-<connect gate="G$3" pin="VOUT" pad="7"/>
+<connect gate="A" pin="VIN+" pad="3"/>
+<connect gate="A" pin="VIN-" pad="2"/>
+<connect gate="A" pin="VOUT" pad="1"/>
+<connect gate="B" pin="VIN+" pad="5"/>
+<connect gate="B" pin="VIN-" pad="6"/>
+<connect gate="B" pin="VOUT" pad="7"/>
+<connect gate="P" pin="GND" pad="4"/>
+<connect gate="P" pin="VDD" pad="8"/>
 </connects>
 <technologies>
 <technology name="">


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024





## Part Description
I messed up naming dual opa originally.



## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?
