### PR TITLE
Oki 78 sr 12/1.0 w36 h c

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -13634,6 +13634,17 @@ Leakage Inductance: 0.50 uH max
 <attribute name="VOLTAGE_CONTINUOUS" value="47.01V"/>
 <attribute name="VOLTAGE_MAX" value="75V"/>
 </technology>
+<technology name="225K">
+<attribute name="DKPN" value="764-M55342E12B225BRWS-ND"/>
+<attribute name="MANUFACTURER" value="Vishay Dale Thin Film"/>
+<attribute name="MOPN" value="" constant="no"/>
+<attribute name="MPN" value="M55342E12B225BRWS"/>
+<attribute name="POWER" value="0.1W"/>
+<attribute name="RESISTANCE" value="225K"/>
+<attribute name="TOLERANCE" value="0.1%"/>
+<attribute name="VOLTAGE_CONTINUOUS" value="150V"/>
+<attribute name="VOLTAGE_MAX" value="200V"/>
+</technology>
 <technology name="240">
 <attribute name="DKPN" value="311-240HRCT-ND"/>
 <attribute name="MANUFACTURER" value="Yageo"/>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -1180,7 +1180,7 @@ visible on the PCB.</text>
 <text x="0" y="3.556" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;Name</text>
 <rectangle x1="-5.08" y1="-3.556" x2="5.08" y2="3.556" layer="39"/>
 </package>
-<package name="OKI-78SR">
+<package name="OKI-78SR(VERTICAL)">
 <description>OKI-78SR Regulator
 &lt;br&gt;
 &lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;Datasheet&lt;/a&gt;</description>
@@ -6746,6 +6746,22 @@ Adapted from &lt;a href="https://www.analog.com/media/en/technical-documentation
 <smd name="1" x="-4.225" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
 <smd name="14" x="4.225" y="-2.775" dx="0.45" dy="1.05" layer="1"/>
 <rectangle x1="-5" y1="-4" x2="5" y2="4" layer="39"/>
+</package>
+<package name="OKI-78SR(HORIZONTAL)">
+<description>OKI-78SR Horizontal
+&lt;br&gt;
+&lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<pad name="1" x="2.54" y="-7.3985" drill="1" first="yes"/>
+<pad name="2" x="0" y="-7.3985" drill="1"/>
+<pad name="3" x="-2.54" y="-7.3985" drill="1"/>
+<wire x1="-5.461" y1="8.8985" x2="5.461" y2="8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="5.461" y1="8.8985" x2="5.461" y2="-8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="5.461" y1="-8.8985" x2="-5.461" y2="-8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.461" y1="-8.8985" x2="-5.461" y2="8.8985" width="0.127" layer="21" style="shortdash"/>
+<text x="0" y="9.652" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
+<rectangle x1="-5.75" y1="-9" x2="5.75" y2="9" layer="39"/>
+<rectangle x1="-3.81" y1="-8.8985" x2="3.81" y2="-5.8985" layer="40"/>
+<circle x="0" y="0" radius="4.99030625" width="0.127" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -17161,7 +17177,7 @@ Recommended load capacitor for the ECS-160-10-42-CKM-TR:
 <gate name="G$1" symbol="VOLTAGE_REGULATOR" x="0" y="0"/>
 </gates>
 <devices>
-<device name="OKI-78SR" package="OKI-78SR">
+<device name="OKI-78SR" package="OKI-78SR(VERTICAL)">
 <connects>
 <connect gate="G$1" pin="GND" pad="2"/>
 <connect gate="G$1" pin="IN" pad="1"/>
@@ -17179,6 +17195,28 @@ Recommended load capacitor for the ECS-160-10-42-CKM-TR:
 <attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
 <attribute name="MOPN" value="580-OKI78SR5/1.5W36C"/>
 <attribute name="MPN" value="OKI-78SR-5/1.5-W36-C"/>
+</technology>
+</technologies>
+</device>
+<device name="" package="OKI-78SR(HORIZONTAL)">
+<connects>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
+</connects>
+<technologies>
+<technology name="12V">
+<attribute name="DKPN" value="811-3294-ND"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
+<attribute name="MOPN" value="580-OKI78SR12/1W36HC"/>
+<attribute name="MPN" value="OKI-78SR-12/1.0-W36H-C"/>
+</technology>
+<technology name="5V">
+<attribute name="DKPN" value="811-2692-ND"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
+<attribute name="MOPN" value="580-OKI78SR51.5W36HC"/>
+<attribute name="MPN" value="OKI-78SR-5/1.5-W36H-C
+"/>
 </technology>
 </technologies>
 </device>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="16" fill="1" visible="yes" active="yes"/>
@@ -191,20 +191,21 @@
 </layers>
 <library>
 <packages>
-<package name="OKI-78SR">
+<package name="OKI-78SR(HORIZONTAL)">
 <description>OKI-78SR Horizontal
 &lt;br&gt;
 &lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<pad name="1" x="2.54" y="0" drill="0.9906" first="yes"/>
-<pad name="2" x="0" y="0" drill="0.9906"/>
-<pad name="3" x="-2.54" y="0" drill="0.9906"/>
-<wire x1="-5.461" y1="13.733" x2="5.461" y2="13.733" width="0.127" layer="21"/>
-<wire x1="5.461" y1="13.733" x2="5.461" y2="-3.937" width="0.127" layer="21"/>
-<wire x1="5.461" y1="-3.937" x2="-5.461" y2="-3.937" width="0.127" layer="21"/>
-<wire x1="-5.461" y1="-3.937" x2="-5.461" y2="13.733" width="0.127" layer="21"/>
-<text x="0" y="5.842" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
-<rectangle x1="-5.588" y1="-4.064" x2="5.588" y2="13.733" layer="39"/>
-<rectangle x1="-3.81" y1="-1.27" x2="3.81" y2="1.27" layer="40"/>
+<pad name="1" x="2.54" y="-7.3985" drill="1" first="yes"/>
+<pad name="2" x="0" y="-7.3985" drill="1"/>
+<pad name="3" x="-2.54" y="-7.3985" drill="1"/>
+<wire x1="-5.461" y1="8.8985" x2="5.461" y2="8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="5.461" y1="8.8985" x2="5.461" y2="-8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="5.461" y1="-8.8985" x2="-5.461" y2="-8.8985" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.461" y1="-8.8985" x2="-5.461" y2="8.8985" width="0.127" layer="21" style="shortdash"/>
+<text x="0" y="9.652" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
+<rectangle x1="-5.75" y1="-9" x2="5.75" y2="9" layer="39"/>
+<rectangle x1="-3.81" y1="-8.8985" x2="3.81" y2="-5.8985" layer="40"/>
+<circle x="0" y="0" radius="4.99030625" width="0.127" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -223,49 +224,6 @@
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="VOLTAGE_REGULATOR_MODULE_?_*" prefix="A">
-<description>Voltage Regulator Modules
-&lt;br&gt;
-&lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;OKI-78SR Datasheet&lt;/a&gt;</description>
-<gates>
-<gate name="G$1" symbol="VOLTAGE_REGULATOR" x="0" y="0"/>
-</gates>
-<devices>
-<device name="OKI-78SR" package="OKI-78SR">
-<connects>
-<connect gate="G$1" pin="GND" pad="2"/>
-<connect gate="G$1" pin="IN" pad="1"/>
-<connect gate="G$1" pin="OUT" pad="3"/>
-</connects>
-<technologies>
-<technology name="12V">
-<attribute name="DKPN" value="811-3293-ND"/>
-<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
-<attribute name="MOPN" value="580-OKI78SR12/1W36C"/>
-<attribute name="MPN" value="OKI-78SR-12/1.0-W36-C"/>
-</technology>
-<technology name="5V">
-<attribute name="DKPN" value="811-2196-5-ND"/>
-<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
-<attribute name="MOPN" value="580-OKI78SR5/1.5W36C"/>
-<attribute name="MPN" value="OKI-78SR-5/1.5-W36-C"/>
-</technology>
-<technology name="HORIZONTAL_12V">
-<attribute name="DKPN" value="811-3294-ND" constant="no"/>
-<attribute name="MANUFACTURER" value="Murata Power Solutions Inc." constant="no"/>
-<attribute name="MOPN" value="580-OKI78SR12/1W36HC" constant="no"/>
-<attribute name="MPN" value="OKI-78SR-12/1.0-W36H-C" constant="no"/>
-</technology>
-<technology name="HORIZONTAL_5V">
-<attribute name="DKPN" value="811-2692-ND" constant="no"/>
-<attribute name="MANUFACTURER" value="Murata Power Solutions Inc." constant="no"/>
-<attribute name="MOPN" value="580-OKI78SR51.5W36HC" constant="no"/>
-<attribute name="MPN" value="OKI-78SR-5/1.5-W36H-C" constant="no"/>
-</technology>
-</technologies>
-</device>
-</devices>
-</deviceset>
 </devicesets>
 </library>
 </drawing>

--- a/EAGLE Libraries/HyTechTemp.lbr
+++ b/EAGLE Libraries/HyTechTemp.lbr
@@ -6,7 +6,7 @@
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="50" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="16" fill="1" visible="yes" active="yes"/>
@@ -191,10 +191,81 @@
 </layers>
 <library>
 <packages>
+<package name="OKI-78SR">
+<description>OKI-78SR Horizontal
+&lt;br&gt;
+&lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<pad name="1" x="2.54" y="0" drill="0.9906" first="yes"/>
+<pad name="2" x="0" y="0" drill="0.9906"/>
+<pad name="3" x="-2.54" y="0" drill="0.9906"/>
+<wire x1="-5.461" y1="13.733" x2="5.461" y2="13.733" width="0.127" layer="21"/>
+<wire x1="5.461" y1="13.733" x2="5.461" y2="-3.937" width="0.127" layer="21"/>
+<wire x1="5.461" y1="-3.937" x2="-5.461" y2="-3.937" width="0.127" layer="21"/>
+<wire x1="-5.461" y1="-3.937" x2="-5.461" y2="13.733" width="0.127" layer="21"/>
+<text x="0" y="5.842" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
+<rectangle x1="-5.588" y1="-4.064" x2="5.588" y2="13.733" layer="39"/>
+<rectangle x1="-3.81" y1="-1.27" x2="3.81" y2="1.27" layer="40"/>
+</package>
 </packages>
 <symbols>
+<symbol name="VOLTAGE_REGULATOR">
+<description>This symbol is not fully style guide compliant, but it was intentionally done to be 0.3" spacing between the pins and easier reading of the small symbol.</description>
+<wire x1="0" y1="-7.62" x2="15.24" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-7.62" x2="15.24" y2="0" width="0.254" layer="94"/>
+<wire x1="15.24" y1="0" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-7.62" width="0.254" layer="94"/>
+<pin name="GND" x="7.62" y="-10.16" visible="pad" length="short" direction="pwr" rot="R90"/>
+<pin name="IN" x="-2.54" y="-2.54" length="short" direction="pwr"/>
+<pin name="OUT" x="17.78" y="-2.54" length="short" direction="sup" rot="R180"/>
+<text x="0" y="0.762" size="1.27" layer="95">&gt;NAME</text>
+<text x="8.89" y="-8.382" size="1.27" layer="96" align="top-left">&gt;MPN</text>
+<text x="7.62" y="-6.35" size="1.524" layer="95" align="bottom-center">GND</text>
+</symbol>
 </symbols>
 <devicesets>
+<deviceset name="VOLTAGE_REGULATOR_MODULE_?_*" prefix="A">
+<description>Voltage Regulator Modules
+&lt;br&gt;
+&lt;a href="https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf"&gt;OKI-78SR Datasheet&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="VOLTAGE_REGULATOR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="OKI-78SR" package="OKI-78SR">
+<connects>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="OUT" pad="3"/>
+</connects>
+<technologies>
+<technology name="12V">
+<attribute name="DKPN" value="811-3293-ND"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
+<attribute name="MOPN" value="580-OKI78SR12/1W36C"/>
+<attribute name="MPN" value="OKI-78SR-12/1.0-W36-C"/>
+</technology>
+<technology name="5V">
+<attribute name="DKPN" value="811-2196-5-ND"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc."/>
+<attribute name="MOPN" value="580-OKI78SR5/1.5W36C"/>
+<attribute name="MPN" value="OKI-78SR-5/1.5-W36-C"/>
+</technology>
+<technology name="HORIZONTAL_12V">
+<attribute name="DKPN" value="811-3294-ND" constant="no"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc." constant="no"/>
+<attribute name="MOPN" value="580-OKI78SR12/1W36HC" constant="no"/>
+<attribute name="MPN" value="OKI-78SR-12/1.0-W36H-C" constant="no"/>
+</technology>
+<technology name="HORIZONTAL_5V">
+<attribute name="DKPN" value="811-2692-ND" constant="no"/>
+<attribute name="MANUFACTURER" value="Murata Power Solutions Inc." constant="no"/>
+<attribute name="MOPN" value="580-OKI78SR51.5W36HC" constant="no"/>
+<attribute name="MPN" value="OKI-78SR-5/1.5-W36H-C" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
 </devicesets>
 </library>
 </drawing>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
Added OKI-78SR(Horizontal) both 5V and 12V footprint and device. Renamed pre-existing OKI-78SR to specify vertical.

## Additional Information
Datasheet (also in Eagle): https://www.mouser.com/datasheet/2/281/oki-78sr-56393.pdf

## Checklist
- [ ] Did you create any new schematics or boards?
- [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [ ] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?
