### PR TITLE
modified molex smd 4pos and 14v tvs footprint

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="10" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="10" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -4448,7 +4448,7 @@ Dashed line is edge of mated connector.</description>
 <wire x1="-2.9986" y1="-4.4323" x2="-4.8274" y2="-2.6035" width="0.127" layer="21"/>
 <wire x1="2.9986" y1="-4.4323" x2="4.8274" y2="-2.6035" width="0.127" layer="21"/>
 <wire x1="4.8274" y1="-2.6035" x2="4.8274" y2="5.4737" width="0.127" layer="21"/>
-<rectangle x1="-7.85" y1="-5.08" x2="7.85" y2="12.7" layer="39"/>
+<rectangle x1="-7.874" y1="-5.08" x2="7.874" y2="6.096" layer="39"/>
 <text x="0" y="-5.207" size="0.8128" layer="25" rot="R180" align="bottom-center">&gt;NAME</text>
 <rectangle x1="-6.1101" y1="1.8034" x2="-3.6717" y2="3.4036" layer="41"/>
 <rectangle x1="3.6717" y1="1.8034" x2="6.1101" y2="3.4036" layer="41"/>
@@ -4467,6 +4467,7 @@ Dashed line is edge of mated connector.</description>
 </polygon>
 <smd name="1" x="1.5" y="5.4737" dx="1.27" dy="2.921" layer="1"/>
 <smd name="3" x="1.5" y="10.0965" dx="1.27" dy="2.921" layer="1"/>
+<rectangle x1="-3.302" y1="6.096" x2="3.302" y2="12.446" layer="39"/>
 </package>
 <package name="MOLEX_MICROFIT_SMD_RIGHTANGLE_08_DUAL">
 <description>8 Pin Micro-Fit Right Angle Header, SMD, Dual Row
@@ -6672,7 +6673,7 @@ Mouser number 538-505110-0492&lt;br&gt;
 <wire x1="1.45" y1="-0.95" x2="1.45" y2="0.95" width="0.127" layer="21"/>
 <wire x1="-1.45" y1="-0.95" x2="-1.45" y2="0.95" width="0.127" layer="21"/>
 <wire x1="-1.45" y1="0.95" x2="1.45" y2="0.95" width="0.127" layer="21"/>
-<text x="0" y="1.27" size="0.8128" layer="25" font="vector" align="bottom-center">&lt;NAME</text>
+<text x="0" y="1.27" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
 <rectangle x1="-2.54" y1="-1.27" x2="2.54" y2="1.27" layer="39"/>
 <wire x1="2.35" y1="0.9" x2="2.35" y2="-0.9" width="0.127" layer="21"/>
 </package>
@@ -17977,8 +17978,7 @@ Neopixel RGBW LED
 <attribute name="DKPN" value="SMBJ5349B-TPMSCT-ND"/>
 <attribute name="MANUFACTURER" value="Micro Commercial Co"/>
 <attribute name="MOPN" value="833-SMBJ5349B-TP"/>
-<attribute name="MPN" value="SMBJ5349B-TP
-"/>
+<attribute name="MPN" value="SMBJ5349B-TP "/>
 <attribute name="VOLTAGE" value="12V"/>
 </technology>
 <technology name="13V">


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
Modified tkeepout for Molex SMD 4pos connector so that components can be placed reasonably close.
Fixed name label for 14V TVS diode footprint

## Additional Information
None

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [x] Did you pull `main` into your branch?
- - [x] Did you *check for merge conflicts*?
- - [x] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [x] Did you fill out the above template?
- [x] Did you assign the right people for review (on the right)?
- [x] Did you comply with the library style guidelines?

