### PR TITLE
TVS_TPSMB_522.5V

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="10" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -19645,7 +19645,9 @@ Note: OPA2991 is also a comparator</description>
 &lt;br&gt;
 &lt;a href="https://www.mouser.com/datasheet/2/427/gsot03-1767593.pdf"&gt;GSOT Datasheet&lt;/a&gt;&lt;br&gt;
 
-&lt;a href="https://www.vishay.com/docs/85881/smf5v0atosmf58a.pdf"&gt;SMF14A Datasheet&lt;/a&gt;</description>
+&lt;a href="https://www.vishay.com/docs/85881/smf5v0atosmf58a.pdf"&gt;SMF14A Datasheet&lt;/a&gt;&lt;br&gt;
+
+&lt;a href="https://www.mouser.com/datasheet/2/240/media-3323583.pdf"&gt;TPSMB Datasheet&lt;/a&gt;</description>
 <gates>
 <gate name="G$1" symbol="DIODE_TVS_UNIDIRECTIONAL" x="0" y="0"/>
 </gates>
@@ -19720,6 +19722,21 @@ Note: OPA2991 is also a comparator</description>
 <attribute name="MOPN" value="78-SMF14A-E3-08"/>
 <attribute name="MPN" value="SMF14A-E3-08"/>
 <attribute name="VOLTAGE" value="14V"/>
+</technology>
+</technologies>
+</device>
+<device name="TPSMB" package="SMB(DO-214AA)">
+<connects>
+<connect gate="G$1" pin="A" pad="A"/>
+<connect gate="G$1" pin="C" pad="C"/>
+</connects>
+<technologies>
+<technology name="522.5">
+<attribute name="DKPN" value="F10341CT-ND"/>
+<attribute name="MANUFACTURER" value="Littelfuse Inc."/>
+<attribute name="MOPN" value="576-TPSMB550CA-A"/>
+<attribute name="MPN" value="TPSMB550CA-A"/>
+<attribute name="VOLTAGE" value="522.5V"/>
 </technology>
 </technologies>
 </device>

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7049,20 +7049,6 @@ Based off orientation demo on page 218 for better STM32 compliance</description>
 <rectangle x1="-8" y1="-8" x2="8" y2="8" layer="39"/>
 <text x="0" y="8" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
 </package>
-<package name="TPSMB">
-<description>DO-214AA Diode Footprint
-&lt;br&gt;
-&lt;a href="https://www.mouser.com/datasheet/2/240/media-3323583.pdf"&gt;Datasheet&lt;/a&gt;</description>
-<wire x1="-2.285" y1="1.97" x2="2.285" y2="1.97" width="0.127" layer="21"/>
-<wire x1="-2.285" y1="-1.97" x2="2.285" y2="-1.97" width="0.127" layer="21"/>
-<wire x1="-2.285" y1="1.97" x2="-2.285" y2="-1.97" width="0.127" layer="21"/>
-<wire x1="2.285" y1="1.97" x2="2.285" y2="-1.97" width="0.127" layer="21"/>
-<smd name="1" x="-2.45" y="0" dx="2.26" dy="2.16" layer="1" rot="R90" thermals="no"/>
-<smd name="2" x="2.45" y="0" dx="2.26" dy="2.16" layer="1" rot="R90" thermals="no"/>
-<rectangle x1="-4.064" y1="-2.286" x2="4.064" y2="2.286" layer="39"/>
-<wire x1="4.064" y1="1.524" x2="4.064" y2="-1.524" width="0.254" layer="21"/>
-<text x="0" y="2.286" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
-</package>
 </packages>
 <symbols>
 <symbol name="VOLTAGE_REGULATOR">

--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="10" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -7048,6 +7048,20 @@ Based off orientation demo on page 218 for better STM32 compliance</description>
 <smd name="2" x="5.325" y="0" dx="3.35" dy="5.3" layer="1" thermals="no"/>
 <rectangle x1="-8" y1="-8" x2="8" y2="8" layer="39"/>
 <text x="0" y="8" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
+</package>
+<package name="TPSMB">
+<description>DO-214AA Diode Footprint
+&lt;br&gt;
+&lt;a href="https://www.mouser.com/datasheet/2/240/media-3323583.pdf"&gt;Datasheet&lt;/a&gt;</description>
+<wire x1="-2.285" y1="1.97" x2="2.285" y2="1.97" width="0.127" layer="21"/>
+<wire x1="-2.285" y1="-1.97" x2="2.285" y2="-1.97" width="0.127" layer="21"/>
+<wire x1="-2.285" y1="1.97" x2="-2.285" y2="-1.97" width="0.127" layer="21"/>
+<wire x1="2.285" y1="1.97" x2="2.285" y2="-1.97" width="0.127" layer="21"/>
+<smd name="1" x="-2.45" y="0" dx="2.26" dy="2.16" layer="1" rot="R90" thermals="no"/>
+<smd name="2" x="2.45" y="0" dx="2.26" dy="2.16" layer="1" rot="R90" thermals="no"/>
+<rectangle x1="-4.064" y1="-2.286" x2="4.064" y2="2.286" layer="39"/>
+<wire x1="4.064" y1="1.524" x2="4.064" y2="-1.524" width="0.254" layer="21"/>
+<text x="0" y="2.286" size="0.8128" layer="25" font="vector" align="bottom-center">&gt;NAME</text>
 </package>
 </packages>
 <symbols>


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
Used existing SMB(DO-214AA) diode footprint and modified attributes of the existing TVS Diode device to create the new 522.5V TVS Diode device. 

## Additional Information
<a href="https://www.mouser.com/datasheet/2/240/media-3323583.pdf">TPSMB Datasheet</a>

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [X] Did you pull `main` into your branch?
- - [X] Did you *check for merge conflicts*?
- - [X] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [X] Did you fill out the above template?
- [X] Did you assign the right people for review (on the right)?
- [X] Did you comply with the library style guidelines?
