### PR TITLE
CONNECTOR-2_MICROFIT_PTH_02_SINGLE_BLACK

### DIFF
--- a/EAGLE Libraries/HyTechDevices.lbr
+++ b/EAGLE Libraries/HyTechDevices.lbr
@@ -12648,6 +12648,20 @@ Isolated Flyback Converter with 630V/300mA Switch
 </technology>
 </technologies>
 </device>
+<device name="MICROFIT_PTH_VERTICAL_02_SINGLE" package="MOLEX_MICROFIT_PTH_VERTICAL_02_SINGLE">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DKPN" value="WM12762-ND"/>
+<attribute name="MANUFACTURER" value="Molex"/>
+<attribute name="MOPN" value="538-43650-0217"/>
+<attribute name="MPN" value="0436500217"/>
+</technology>
+</technologies>
+</device>
 </devices>
 </deviceset>
 <deviceset name="CAPACITOR_?_*" prefix="C">


### PR DESCRIPTION
# Pull Request (PR) into Circuits-Support-2024

## Part Description
Connected MOLEX_MICROFIT_PTH_VERTICAL_02_SINGLE footprint with CONNECTOR_02 symbol in order to recreate a 2-pin connector that was missing in the HyTech Devices Library. 

## Additional Information
<a href="https://tools.molex.com/pdm_docs/ps/PS-43650.pdf">Datasheet</a>

## Checklist
- [ ] Did you create any new schematics or boards?
- - [ ] Did you *make a PR* for them in `circuits-2024`? If so, please pause until you get this PR merged.
- [X] Did you pull `main` into your branch?
- - [X] Did you *check for merge conflicts*?
- - [X] Did you *resolve* any that occurred? ***If you are having trouble or are confused, contact a lead!***
- [X] Did you fill out the above template?
- [X] Did you assign the right people for review (on the right)?
- [X] Did you comply with the library style guidelines?
